### PR TITLE
修复 Red 适配器撤回私聊报错的问题

### DIFF
--- a/nonebot_plugin_saa/adapters/red.py
+++ b/nonebot_plugin_saa/adapters/red.py
@@ -76,7 +76,8 @@ try:
     @register_target_extractor(GroupMessageEvent)
     def _extract_group_msg_event(event: Event) -> TargetQQGroup:
         assert isinstance(event, GroupMessageEvent)
-        return TargetQQGroup(group_id=int(event.peerUid))
+        assert event.peerUin, "peerUin should not be None for group message"
+        return TargetQQGroup(group_id=int(event.peerUin))
 
     @register_convert_to_arg(adapter, SupportedPlatform.qq_private)
     def _gen_private(target: PlatformTarget) -> Dict[str, Any]:
@@ -99,9 +100,10 @@ try:
         message: MessageModel
 
         async def revoke(self):
+            assert self.message.peerUin, "peerUin should not be None"
             return await cast(BotRed, self._get_bot()).recall_message(
                 self.message.chatType,
-                self.message.peerUid,
+                self.message.peerUin,
                 self.message.msgId,
             )
 

--- a/tests/test_red.py
+++ b/tests/test_red.py
@@ -321,7 +321,7 @@ async def test_send_revoke(app: App):
         )
         ctx.should_call_api(
             "recall_message",
-            data={"chat_type": 1, "target": "4321", "msg_ids": ["7272944767457625851"]},
+            data={"chat_type": 1, "target": "1234", "msg_ids": ["7272944767457625851"]},
         )
 
 


### PR DESCRIPTION
应该需要用 peerUin，不过我还是没理清楚这两个的区别。