### PR TITLE
捕获 auto select bot 功能中的各处异常

### DIFF
--- a/nonebot_plugin_saa/adapters/onebot_v11.py
+++ b/nonebot_plugin_saa/adapters/onebot_v11.py
@@ -243,14 +243,22 @@ try:
         assert isinstance(bot, BotOB11)
 
         targets = []
-        groups = await bot.get_group_list()
+        try:
+            groups = await bot.get_group_list()
+        except Exception:
+            groups = []
+
         for group in groups:
             group_id = group["group_id"]
             target = TargetQQGroup(group_id=group_id)
             targets.append(target)
 
         # 获取好友列表
-        users = await bot.get_friend_list()
+        try:
+            users = await bot.get_friend_list()
+        except Exception:
+            users = []
+
         for user in users:
             user_id = user["user_id"]
             target = TargetQQPrivate(user_id=user_id)

--- a/nonebot_plugin_saa/adapters/red.py
+++ b/nonebot_plugin_saa/adapters/red.py
@@ -199,14 +199,20 @@ try:
         assert isinstance(bot, BotRed)
 
         targets = []
-        groups = await bot.get_groups()
+        try:
+            groups = await bot.get_groups()
+        except Exception:
+            groups = []
         for group in groups:
             group_id = int(group.groupCode)
             target = TargetQQGroup(group_id=group_id)
             targets.append(target)
 
         # 获取好友列表
-        users = await bot.get_friends()
+        try:
+            users = await bot.get_friends()
+        except Exception:
+            users = []
         for user in users:
             user_id = int(user.uin)
             target = TargetQQPrivate(user_id=user_id)

--- a/nonebot_plugin_saa/auto_select_bot.py
+++ b/nonebot_plugin_saa/auto_select_bot.py
@@ -74,8 +74,11 @@ async def _refresh_bot(bot: Bot):
     BOT_CACHE.pop(bot, None)
     adapter_name = extract_adapter_type(bot)
     if list_targets := list_targets_map.get(adapter_name):
-        targets = await list_targets(bot)
-        BOT_CACHE[bot] = set(targets)
+        try:
+            targets = await list_targets(bot)
+            BOT_CACHE[bot] = set(targets)
+        except Exception:
+            logger.exception(f"{bot} get list targets failed")
     _info_current()
 
 

--- a/nonebot_plugin_saa/auto_select_bot.py
+++ b/nonebot_plugin_saa/auto_select_bot.py
@@ -8,13 +8,13 @@ import nonebot
 from nonebot.adapters import Bot
 from nonebot import logger, get_bots
 
+from .registries import BotSpecifier, PlatformTarget, TargetQQGuildDirect
 from .utils import (
     NoBotFound,
     SupportedAdapters,
-    extract_adapter_type,
     AdapterNotSupported,
+    extract_adapter_type,
 )
-from .registries import BotSpecifier, PlatformTarget, TargetQQGuildDirect
 
 BOT_CACHE: Dict[Bot, Set[PlatformTarget]] = {}
 BOT_CACHE_LOCK = asyncio.Lock()

--- a/nonebot_plugin_saa/auto_select_bot.py
+++ b/nonebot_plugin_saa/auto_select_bot.py
@@ -8,7 +8,12 @@ import nonebot
 from nonebot.adapters import Bot
 from nonebot import logger, get_bots
 
-from .utils import NoBotFound, SupportedAdapters, extract_adapter_type
+from .utils import (
+    NoBotFound,
+    SupportedAdapters,
+    extract_adapter_type,
+    AdapterNotSupported,
+)
 from .registries import BotSpecifier, PlatformTarget, TargetQQGuildDirect
 
 BOT_CACHE: Dict[Bot, Set[PlatformTarget]] = {}
@@ -72,7 +77,12 @@ def register_list_targets(adapter: SupportedAdapters):
 
 async def _refresh_bot(bot: Bot):
     BOT_CACHE.pop(bot, None)
-    adapter_name = extract_adapter_type(bot)
+    try:
+        adapter_name = extract_adapter_type(bot)
+    except AdapterNotSupported as e:
+        logger.warning(f"{bot} adapter [{e.args[0]}] not supported, ignore")
+        return
+
     if list_targets := list_targets_map.get(adapter_name):
         try:
             targets = await list_targets(bot)

--- a/tests/test_onebot_v11.py
+++ b/tests/test_onebot_v11.py
@@ -235,13 +235,18 @@ async def test_send_aggreted_ob11(app: App):
 
 async def test_list_targets(app: App, mocker: MockerFixture):
     from nonebot_plugin_saa import TargetQQGroup, TargetQQPrivate
-    from nonebot_plugin_saa.auto_select_bot import get_bot, refresh_bots
+    from nonebot_plugin_saa.auto_select_bot import BOT_CACHE, get_bot, refresh_bots
 
     mocker.patch("nonebot_plugin_saa.auto_select_bot.inited", True)
 
     async with app.test_api() as ctx:
         adapter = get_adapter(Adapter)
         bot = ctx.create_bot(base=Bot, adapter=adapter)
+
+        ctx.should_call_api("get_group_list", {}, exception=Exception("test"))
+        ctx.should_call_api("get_friend_list", {}, exception=Exception("test"))
+        await refresh_bots()
+        assert not BOT_CACHE.get(bot)
 
         ctx.should_call_api("get_group_list", {}, [{"group_id": 112}])
         ctx.should_call_api("get_friend_list", {}, [{"user_id": 1122}])

--- a/tests/test_red.py
+++ b/tests/test_red.py
@@ -340,13 +340,18 @@ async def test_send_revoke(app: App):
 
 async def test_list_targets(app: App, mocker: MockerFixture):
     from nonebot_plugin_saa import TargetQQGroup, TargetQQPrivate
-    from nonebot_plugin_saa.auto_select_bot import get_bot, refresh_bots
+    from nonebot_plugin_saa.auto_select_bot import BOT_CACHE, get_bot, refresh_bots
 
     mocker.patch("nonebot_plugin_saa.auto_select_bot.inited", True)
 
     async with app.test_api() as ctx:
         adapter = get_adapter(Adapter)
         bot = ctx.create_bot(base=Bot, adapter=adapter, info=bot_info)
+
+        ctx.should_call_api("get_groups", data={}, exception=Exception("test"))
+        ctx.should_call_api("get_friends", data={}, exception=Exception("test"))
+        await refresh_bots()
+        assert not BOT_CACHE.get(bot)
 
         ctx.should_call_api(
             "get_groups",


### PR DESCRIPTION
- OB11/Red 在 list_targets 中调用api失败会返回空列表
- _refresh_bots 中 调用 list_targets 失败时不再直接抛出异常
- _refresh_bots 中遇到不支持的适配器时不再抛出 AdapterNotSupported 而是忽略