### PR TITLE
修复注释参数错误

### DIFF
--- a/nonebot_plugin_saa/registries/platform_send_target.py
+++ b/nonebot_plugin_saa/registries/platform_send_target.py
@@ -204,7 +204,7 @@ class TargetTelegramCommon(PlatformTarget):
     """Telegram 普通对话
 
     参数
-        user_id: 对话ID
+        chat_id: 对话ID
     """
 
     platform_type: Literal[SupportedPlatform.telegram_common] = (


### PR DESCRIPTION
TargetTelegramCommon 注释参数原本写的是 user_id ，但在代码中为 chat_id ，且在测试中也使用的是 chat_id ，所以修改注释中的  user_id 为 chat_id